### PR TITLE
Fix automatic user addition to a group of himself

### DIFF
--- a/protector/models.py
+++ b/protector/models.py
@@ -28,7 +28,7 @@ from protector.managers import (
     RestrictedManager,
     GenericGroupManager,
 )
-from protector.reserved_reasons import MEMBER_FK_UPDATE_REASON
+from protector.reserved_reasons import MEMBER_FK_UPDATE_REASON, SELF_GROUP_ROLE_UPDATED
 
 
 #  Form a from clause for all permission related to their owners
@@ -311,16 +311,22 @@ class OwnerToPermission(AbstractOwnerToPermission):
             # Here is a bit of denormalization
             # User is a part of group of his own
             # This is done to drastically improve perm checking performance
-            GenericUserToGroup.objects.get_or_create(
+            self_role = 1  # role == 1 in user model is assumed to mean user himself
+            generic_user_to_group, created = GenericUserToGroup.objects.get_or_create(
                 reason=kwargs.get('reason'),
                 group_id=self.owner_object_id,
                 group_content_type=self.owner_content_type,
                 user_id=self.owner_object_id,
-                roles=1,
                 defaults={
                     'responsible': kwargs.get('responsible'),
+                    'roles': self_role,
                 }
             )
+            if not generic_user_to_group.roles & self_role:
+                # If (for some reason) user is a part of group of his own without self role (1),
+                # we ensure that self role is included
+                generic_user_to_group.roles |= self_role
+                generic_user_to_group.save(reason=SELF_GROUP_ROLE_UPDATED)
         try:
             del kwargs['reason']
         except KeyError:

--- a/protector/reserved_reasons.py
+++ b/protector/reserved_reasons.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 TEST_REASON = 'TEST REASON'
 GENERIC_GROUP_UPDATE_REASON = 'Groups were created due to foreign key links update'
+SELF_GROUP_ROLE_UPDATED = 'Self-role added for user own group'
 
 
 def ADMIN_PANEL_DELETE_REASON(user):

--- a/test_project/test_app/models.py
+++ b/test_project/test_app/models.py
@@ -22,7 +22,14 @@ class TestGroup(AbstractGenericGroup, Restricted):
         verbose_name = u'Test Group'
 
 
-class TestUser(UserGenericPermsMixin, AbstractBaseUser):
+class TestUser(AbstractGenericGroup, UserGenericPermsMixin, AbstractBaseUser):
+    SELF = 1
+    ASSISTANT = 1 << 2
+    ROLES = (
+        (SELF, 'User'),
+        (ASSISTANT, 'Assistant'),
+    )
+
     USERNAME_FIELD = 'username'
     REQUIRED_FIELDS = ('email', )
     username = models.CharField(max_length=30, unique=True)


### PR DESCRIPTION
When `OwnerToPermission` object is created for user, we automatically add user to group of his own (if he hadn't been added yet). But if user had already been added to this self-group with `roles` != 1, current code will fail on `GenericUserToGroup` unique key `('group_id', 'group_content_type', 'user')`.  