### PR TITLE
fixed: GenericUserToGroup manager add method duplicates history records

### DIFF
--- a/protector/managers.py
+++ b/protector/managers.py
@@ -113,7 +113,7 @@ class GroupUserManager(models.Manager):
                 reason=reason,
                 defaults={'roles': roles, 'responsible': responsible}
             )
-            if not created:
+            if not created and gug.roles != roles:
                 gug.roles |= roles
                 gug.save(reason=reason)
 


### PR DESCRIPTION
Вызов `.users.add` для пользователя, у которого эта роль уже выдана, приводил к обязательному вызову `.save()`, что в последствии приводило к созданию новой записи истории, даже если роль пользователя не поменялась