### PR TITLE
Delete protector entry group while removing entry.

### DIFF
--- a/protector/models.py
+++ b/protector/models.py
@@ -495,7 +495,7 @@ class AbstractGenericGroup(GenericPermsMixin):
             GenericUserToGroup.objects.filter(
                 group_id=self.pk,
                 group_content_type_id=ContentType.objects.get_for_model(self).id
-            )
+            ).delete()
         return result
 
     def _update_member_foreign_key(self):

--- a/protector/models.py
+++ b/protector/models.py
@@ -492,7 +492,9 @@ class AbstractGenericGroup(GenericPermsMixin):
     def delete(self, *args, **kwargs):
         result = super().delete(*args, **kwargs)
         if self.Meta.delete_protector_group:
-            GenericUserToGroup.objects.filter(group_id=self.pk, group_content_type=type(self).__name__.lower())
+            GenericUserToGroup.objects.filter(
+                group_id=self.pk,
+                group_content_type__id=ContentType.objects.get_for_model(self).id)
         return result
 
     def _update_member_foreign_key(self):

--- a/protector/models.py
+++ b/protector/models.py
@@ -494,7 +494,8 @@ class AbstractGenericGroup(GenericPermsMixin):
         if self.Meta.delete_protector_group:
             GenericUserToGroup.objects.filter(
                 group_id=self.pk,
-                group_content_type__id=ContentType.objects.get_for_model(self).id)
+                group_content_type__id=ContentType.objects.get_for_model(self).id
+            )
         return result
 
     def _update_member_foreign_key(self):

--- a/protector/models.py
+++ b/protector/models.py
@@ -479,6 +479,7 @@ class AbstractGenericGroup(GenericPermsMixin):
 
     class Meta:
         abstract = True
+        delete_protector_group = True
 
     def __init__(self, *args, **kwargs):
         super(AbstractGenericGroup, self).__init__(*args, **kwargs)
@@ -487,6 +488,12 @@ class AbstractGenericGroup(GenericPermsMixin):
     def save(self, *args, **kwargs):
         super(AbstractGenericGroup, self).save(*args, **kwargs)
         self._update_member_foreign_key()
+
+    def delete(self, *args, **kwargs):
+        result = super().delete(*args, **kwargs)
+        if self.Meta.delete_protector_group:
+            GenericUserToGroup.objects.filter(group_id=self.pk, group_content_type=type(self).__name__.lower())
+        return result
 
     def _update_member_foreign_key(self):
         for field, roles in self.MEMBER_FOREIGN_KEY_FIELDS:

--- a/protector/models.py
+++ b/protector/models.py
@@ -494,7 +494,7 @@ class AbstractGenericGroup(GenericPermsMixin):
         if self.Meta.delete_protector_group:
             GenericUserToGroup.objects.filter(
                 group_id=self.pk,
-                group_content_type__id=ContentType.objects.get_for_model(self).id
+                group_content_type_id=ContentType.objects.get_for_model(self).id
             )
         return result
 


### PR DESCRIPTION
Let's remove dependent entries in GenericUserToGroup model while removing entry, restricted by Protector. Goal is avoiding obsolete entries after removing.