### PR TITLE
Fix cascade deletion OwnerToPermission while deletion object.

### DIFF
--- a/protector/models.py
+++ b/protector/models.py
@@ -375,7 +375,10 @@ class GenericPermsMixin(models.Model):
     """
         Mixin is can be used to easily retrieve all owners of permissions to this object
     """
-    permission_relations = GenericRelation(OwnerToPermission)
+    permission_relations = GenericRelation(
+        OwnerToPermission, content_type_field='owner_content_type',
+        object_id_field='owner_object_id'
+    )
 
     permissions = None
 
@@ -472,9 +475,9 @@ class AbstractGenericGroup(GenericPermsMixin):
         object_id_field='group_id'
     )
 
+    content_object_relations = GenericRelation(OwnerToPermission)
+
     objects = GenericGroupManager()
-    
-    delete_protector_group = True
 
     class Meta:
         abstract = True

--- a/protector/models.py
+++ b/protector/models.py
@@ -375,10 +375,7 @@ class GenericPermsMixin(models.Model):
     """
         Mixin is can be used to easily retrieve all owners of permissions to this object
     """
-    permission_relations = GenericRelation(
-        OwnerToPermission, content_type_field='owner_content_type',
-        object_id_field='owner_object_id'
-    )
+    permission_relations = GenericRelation(OwnerToPermission)
 
     permissions = None
 
@@ -489,15 +486,6 @@ class AbstractGenericGroup(GenericPermsMixin):
     def save(self, *args, **kwargs):
         super(AbstractGenericGroup, self).save(*args, **kwargs)
         self._update_member_foreign_key()
-
-    def delete(self, *args, **kwargs):
-        result = super().delete(*args, **kwargs)
-        if self.delete_protector_group:
-            GenericUserToGroup.objects.filter(
-                group_id=self.pk,
-                group_content_type_id=ContentType.objects.get_for_model(self).id
-            ).delete()
-        return result
 
     def _update_member_foreign_key(self):
         for field, roles in self.MEMBER_FOREIGN_KEY_FIELDS:

--- a/protector/tests.py
+++ b/protector/tests.py
@@ -809,7 +809,10 @@ class TestCascadeDeletion(TestCase):
 
         self.assertTrue(GenericUserToGroup.objects.filter(pk=gutg.pk).exists())
         self.user.delete()
-        self.assertFalse(GenericUserToGroup.objects.filter(pk=gutg.pk).exists())
+        self.assertFalse(
+            GenericUserToGroup.objects.filter(pk=gutg.pk).exists(),
+            'GenericUserToGroup not cascade deleted after deleting user'
+        )
 
     def test_deletion_owner_to_permission(self):
         TestGroup = get_default_group_ctype().model_class()
@@ -824,4 +827,6 @@ class TestCascadeDeletion(TestCase):
 
         self.assertTrue(OwnerToPermission.objects.filter(pk=otp.pk).exists())
         obj.delete()
-        self.assertFalse(OwnerToPermission.objects.filter(pk=otp.pk).exists())
+        self.assertFalse(
+            OwnerToPermission.objects.filter(pk=otp.pk).exists(),
+            'OwnerToPermission not cascade deleted after deleting content_object')


### PR DESCRIPTION
If override `content_type_field` and `object_id_field` for `permission_relations` in `protector.models.GenericPermsMixin`, then django delete [collector](https://github.com/django/django/blob/stable/3.1.x/django/db/models/base.py#L946) will work not properly. Collector will try to find `OwnerToPermission` with `owner_content_type=object_content_type` and `owner_object_id=object_id`.

Check [django.contrib.contenttypes.fields.GenericRelation.bulk_related_objects](https://github.com/django/django/blob/stable/3.1.x/django/contrib/contenttypes/fields.py#L482)